### PR TITLE
Move everything except usings out of IJuliaCore.jl

### DIFF
--- a/src/IJuliaCore.jl
+++ b/src/IJuliaCore.jl
@@ -1,40 +1,8 @@
 module IJuliaCore
 
-#######################################################################
-# Debugging IJulia
+using JSON
+using Printf
 
-# in the Jupyter front-end, enable verbose output via IJulia.set_verbose()
-verbose = false
-"""
-    set_verbose(v=true)
-
-This function enables (or disables, for `set_verbose(false)`) verbose
-output from the IJulia kernel, when called within a running notebook.
-This consists of log messages printed to the terminal window where
-`jupyter` was launched, displaying information about every message sent
-or received by the kernel.   Used for debugging IJulia.
-"""
-function set_verbose(v::Bool=true)
-    global verbose = v
-end
-
-
-# set this to false for debugging, to disable stderr redirection
-"""
-The IJulia kernel captures all [stdout and stderr](https://en.wikipedia.org/wiki/Standard_streams)
-output and redirects it to the notebook.   When debugging IJulia problems,
-however, it can be more convenient to *not* capture stdout and stderr output
-(since the notebook may not be functioning). This can be done by editing
-`IJulia.jl` to set `capture_stderr` and/or `capture_stdout` to `false`.
-"""
-const capture_stdout = true
-const capture_stderr = true
-
-
-include("init.jl")
-include("stdio.jl")
-include("display.jl")
-include("execute_request.jl")
-include("inline.jl")
+include("packagedef.jl")
 
 end

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1,0 +1,36 @@
+#######################################################################
+# Debugging IJulia
+
+# in the Jupyter front-end, enable verbose output via IJulia.set_verbose()
+verbose = false
+"""
+    set_verbose(v=true)
+
+This function enables (or disables, for `set_verbose(false)`) verbose
+output from the IJulia kernel, when called within a running notebook.
+This consists of log messages printed to the terminal window where
+`jupyter` was launched, displaying information about every message sent
+or received by the kernel.   Used for debugging IJulia.
+"""
+function set_verbose(v::Bool=true)
+    global verbose = v
+end
+
+
+# set this to false for debugging, to disable stderr redirection
+"""
+The IJulia kernel captures all [stdout and stderr](https://en.wikipedia.org/wiki/Standard_streams)
+output and redirects it to the notebook.   When debugging IJulia problems,
+however, it can be more convenient to *not* capture stdout and stderr output
+(since the notebook may not be functioning). This can be done by editing
+`IJulia.jl` to set `capture_stderr` and/or `capture_stdout` to `false`.
+"""
+const capture_stdout = true
+const capture_stderr = true
+
+
+include("init.jl")
+include("stdio.jl")
+include("display.jl")
+include("execute_request.jl")
+include("inline.jl")

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -39,7 +39,6 @@ end
 # logging in verbose mode goes to original stdio streams.  Use macros
 # so that we do not even evaluate the arguments in no-verbose modes
 
-using Printf
 function get_log_preface()
     t = now()
     taskname = get(task_local_storage(), :IJulia_task, "")


### PR DESCRIPTION
We need to do it this way so that we can completely vendore IJuliaCore.jl into the VS Code extension. We've been using the same pattern for the JuliaInterpreter and Revise stack as well, and it has worked great.

From IJulia.jl's point of view this doesn't really matter at all, it just splits existing codes in a slightly different way across files.